### PR TITLE
fix: prettier config

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -33,7 +33,7 @@ export default function hagemanto(options = {}) {
 				"hagemanto/case-blocks": "error",
 				"hagemanto/no-instanceof": "error",
 
-				...(options.enablePrettier ? [{
+				...(options.enablePrettier ? {
 					"prettier/prettier": [
 						"error",
 						{
@@ -47,7 +47,7 @@ export default function hagemanto(options = {}) {
 							useTabs: true,
 						},
 					],
-				}] : []),
+				} : {}),
 
 				"@stylistic/ts/padding-line-between-statements": [
 					"error",


### PR DESCRIPTION
```
❯ pnpm eslint --fix --cache --no-ignore

Oops! Something went wrong! :(

ESLint: 9.9.1

Configuration for rule "0" is invalid. Each rule must have a severity ("off", 0, "warn", 1, "error", or 2) and may be followed by additional options for the rule.

You passed '{
        "prettier/prettier": [
            "error",
            {
                "printWidth": 100,
                "tabWidth": 4,
                "semi": true,
                "singleQuote": false,
                "trailingComma": "es5",
                "bracketSpacing": true,
                "endOfLine": "lf",
                "useTabs": true
            }
        ]
    }', which doesn't contain a valid severity.

If you're attempting to configure rule options, perhaps you meant:

    "0": ["error", {
            "prettier/prettier": [
                "error",
                {
                    "printWidth": 100,
                    "tabWidth": 4,
                    "semi": true,
                    "singleQuote": false,
                    "trailingComma": "es5",
                    "bracketSpacing": true,
                    "endOfLine": "lf",
                    "useTabs": true
                }
            ]
        }]

See https://eslint.org/docs/latest/use/configure/rules#using-configuration-files for configuring rules.
```

fixes the above when running with `enablePrettier: true`